### PR TITLE
Add WebTorrent Desktop; better WebTorrent version parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,6 +179,21 @@ var VER_AZ_TRANSMISSION_STYLE = function(v) {
 	}
 	return v[0] + '.' + v[1] + v[2] + (v[3] == 'Z' || v[3] == 'X' ? "+" : "")
 };
+var VER_AZ_WEBTORRENT_STYLE = function(v) {
+	// "webtorrent"
+	var version = ''
+	if (v[0] == '0') {
+		version += v[1] + '.'
+	} else {
+		version += '' + v[0] + v[1] + '.'
+	}
+	if (v[2] == '0') {
+		version += v[3]
+	} else {
+		version += '' + v[2] + v[3]
+	}
+	return version
+};
 var VER_AZ_THREE_ALPHANUMERIC_DIGITS = "2.33.4"
 var VER_NONE = "NO_VERSION"
 
@@ -323,8 +338,9 @@ function getAzStyleClientVersion (client, peerId) {
 	addAzStyle("UE", "\u00B5Torrent Embedded", VER_AZ_THREE_DIGITS_PLUS_MNEMONIC)
 	addAzStyle("UT", "\u00B5Torrent", VER_AZ_THREE_DIGITS_PLUS_MNEMONIC)
 	addAzStyle("UM", "\u00B5Torrent Mac", VER_AZ_THREE_DIGITS_PLUS_MNEMONIC)
+	addAzStyle("WD", "WebTorrent Desktop", VER_AZ_WEBTORRENT_STYLE)// Go Webtorrent!! :)
 	addAzStyle("WT", "Bitlet")
-	addAzStyle("WW", "WebTorrent")// Go Webtorrent!! :)
+	addAzStyle("WW", "WebTorrent", VER_AZ_WEBTORRENT_STYLE)// Go Webtorrent!! :)
 	addAzStyle("WY", "FireTorrent")// formerly Wyzo.
 	addAzStyle("VG", "\u54c7\u560E (Vagaa)", VER_AZ_FOUR_DIGITS)
 	addAzStyle("XL", "\u8FC5\u96F7\u5728\u7EBF (Xunlei)")// Apparently, the English name of the client is "Thunderbolt".

--- a/package.json
+++ b/package.json
@@ -6,10 +6,9 @@
   "bugs": {
     "url": "https://github.com/fisch0920/bittorrent-peerid/issues"
   },
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
-    "tape": "^2.5.0"
+    "tape": "^4.6.0"
   },
   "homepage": "https://github.com/fisch0920/bittorrent-peerid",
   "keywords": [

--- a/test/basic.js
+++ b/test/basic.js
@@ -138,8 +138,23 @@ test('Unknown clients', function (t) {
   t.end()
 })
 
-test('Webtorrent', function (t) {
-  t.equal(peerid("-WW0000-Em6o1EmvwLtD").client, "WebTorrent")
-  t.end()
+test('WebTorrent', function (t) {
+	var parsed = peerid("-WW0000-Em6o1EmvwLtD")
+	t.equal(parsed.client, "WebTorrent")
+	t.equal(parsed.version, "0.0")
+	t.equal(peerid("-WW0100-Em6o1EmvwLtD").version, "1.0")
+	t.equal(peerid("-WW1000-Em6o1EmvwLtD").version, "10.0")
+	t.equal(peerid("-WW0001-Em6o1EmvwLtD").version, "0.1")
+	t.equal(peerid("-WW0010-Em6o1EmvwLtD").version, "0.10")
+	t.equal(peerid("-WW0011-Em6o1EmvwLtD").version, "0.11")
+	t.equal(peerid("-WW1011-Em6o1EmvwLtD").version, "10.11")
+	t.equal(peerid("-WW1111-Em6o1EmvwLtD").version, "11.11")
+	t.end()
 })
 
+test('WebTorrent Desktop', function (t) {
+	var parsed = peerid("-WD0007-Em6o1EmvwLtD")
+	t.equal(parsed.client, "WebTorrent Desktop")
+	t.equal(parsed.version, "0.7")
+	t.end()
+})


### PR DESCRIPTION
- Added the new peer ID for WebTorrent Desktop (WD).
- Support parsing the WebTorrent version correctly.